### PR TITLE
feat: staging同期ワークフローを追加

### DIFF
--- a/.github/workflows/sync-staging-after-merge.yml
+++ b/.github/workflows/sync-staging-after-merge.yml
@@ -1,0 +1,38 @@
+name: Sync staging branch after merge
+
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - develop
+
+jobs:
+  sync-staging:
+    # Only run when PR is merged (not just closed) and from staging-#* branch
+    if: |
+      github.event.pull_request.merged == true &&
+      startsWith(github.event.pull_request.head.ref, 'staging-#')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Sync staging with develop
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          # Fetch latest develop
+          git fetch origin develop
+
+          # Update staging branch to match develop
+          git checkout staging
+          git reset --hard origin/develop
+          git push origin staging --force
+
+          echo "Synced staging branch with develop"


### PR DESCRIPTION
## Summary
- `staging-#*` ブランチが `develop` にマージされた後、`staging` ブランチを `develop` と同期するワークフローを追加

## 追加ファイル
- `.github/workflows/sync-staging-after-merge.yml`

## 動作
1. `staging-#*` → `develop` へのPRがマージされた時にトリガー
2. `staging` ブランチを `develop` の最新状態に強制プッシュで同期

## 注意
Rulesetで `staging` ブランチが保護されている場合、`github-actions[bot]` にバイパス権限が必要です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)